### PR TITLE
bug fix

### DIFF
--- a/mythos/utils/helpers.py
+++ b/mythos/utils/helpers.py
@@ -82,7 +82,7 @@ def run_command(cmd: list[str], cwd: Path, log_prefix: str = "command-output", e
         err_lines = tail_file(err_file, n=err_tail_lines)
         out_lines = tail_file(out_file, n=err_tail_lines)
         raise RuntimeError(
-            f"Command {' '.join(cmd)} failed with exit code {e.returncode}.\n"
+            f"Command {cmd} failed with exit code {e.returncode}.\n"
             f"  Last {err_tail_lines} lines of stdout:\n{out_lines}\n"
             f"  Last {err_tail_lines} lines of stderr:\n{err_lines}\n"
         ) from e


### PR DESCRIPTION
This fixes a bug(ish) in error for run command. The command could contain Path object components. Instead of wiring a fancy formatter, we can just dump the object verbatim (objects must be stringifyable for command anyhow)