### PR TITLE
energy call signature change

### DIFF
--- a/mythos/energy/dna1/nucleotide.py
+++ b/mythos/energy/dna1/nucleotide.py
@@ -4,7 +4,7 @@ import chex
 import jax_md
 
 import mythos.energy.base as je_base
-import mythos.energy.utils as je_utils
+import mythos.utils.math as ju_math
 import mythos.utils.types as typ
 
 
@@ -33,9 +33,9 @@ class Nucleotide(je_base.BaseNucleotide):
         com_to_stacking: typ.Scalar,
     ) -> "Nucleotide":
         """Class method to precompute nucleotide sites from a rigid body."""
-        back_base_vectors = je_utils.q_to_back_base(rigid_body.orientation)
-        base_normals = je_utils.q_to_base_normal(rigid_body.orientation)
-        cross_prods = je_utils.q_to_cross_prod(rigid_body.orientation)
+        back_base_vectors = ju_math.q_to_back_base(rigid_body.orientation)
+        base_normals = ju_math.q_to_base_normal(rigid_body.orientation)
+        cross_prods = ju_math.q_to_cross_prod(rigid_body.orientation)
 
         stack_sites = rigid_body.center + com_to_stacking * back_base_vectors
         back_sites = rigid_body.center + com_to_backbone * back_base_vectors

--- a/mythos/energy/dna1/tests/test_expected_energies.py
+++ b/mythos/energy/dna1/tests/test_expected_energies.py
@@ -12,6 +12,7 @@ import mythos.input.sequence_constraints as jd_sc
 import mythos.input.toml as jd_toml
 import mythos.input.topology as jd_top
 import mythos.input.trajectory as jd_traj
+import mythos.simulators.io as jd_sio
 import mythos.utils.constants as jd_const
 import mythos.utils.types as typ
 
@@ -133,7 +134,7 @@ def test_hydrogen_bonding_discrete(base_dir: str):
     ).with_params(pseq=pseq, pseq_constraints=sc)
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-3)
 
@@ -200,12 +201,12 @@ def test_hydrogen_bonding_brute_force():
 
     states = trajectory.state_rigid_body
 
-    energy = energy_fn.with_params(pseq=pseq, pseq_constraints=sc).map(states)
+    energy = energy_fn.with_params(pseq=pseq, pseq_constraints=sc).map(jd_sio.SimulatorTrajectory(rigid_body=states))
 
     @jax.jit
     def compute_base_vals(dseq):
         """Compute the per-state energies given a discrete sequence."""
-        return energy_fn.with_props(seq=dseq).map(states)
+        return energy_fn.with_props(seq=dseq).map(jd_sio.SimulatorTrajectory(rigid_body=states))
 
     # Brute force calculation
     assert len(jd_const.BP_TYPES) == len(jd_const.DNA_ALPHA)
@@ -293,12 +294,12 @@ def test_stacking_brute_force():
 
     states = trajectory.state_rigid_body
 
-    energy = energy_fn.with_params(pseq=pseq, pseq_constraints=sc).map(states)
+    energy = energy_fn.with_params(pseq=pseq, pseq_constraints=sc).map(jd_sio.SimulatorTrajectory(rigid_body=states))
 
     @jax.jit
     def compute_base_vals(dseq):
         """Compute the per-state energies given a discrete sequence."""
-        return energy_fn.with_props(seq=dseq).map(states)
+        return energy_fn.with_props(seq=dseq).map(jd_sio.SimulatorTrajectory(rigid_body=states))
 
     # Brute force calculation
     assert len(jd_const.BP_TYPES) == len(jd_const.DNA_ALPHA)

--- a/mythos/energy/dna1/tests/test_integration.py
+++ b/mythos/energy/dna1/tests/test_integration.py
@@ -12,6 +12,7 @@ import mythos.energy.dna1 as jd_energy
 import mythos.input.toml as jd_toml
 import mythos.input.topology as jd_top
 import mythos.input.trajectory as jd_traj
+import mythos.simulators.io as jd_sio
 from mythos.input.sequence_constraints import dseq_to_pseq, from_bps
 from mythos.input.sequence_dependence import read_ss_weights
 
@@ -99,7 +100,7 @@ def test_bonded_excluded_volume(base_dir: str):
     )
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-6)
 
@@ -131,7 +132,7 @@ def test_coaxial_stacking(base_dir: str):
     )
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-6)
 
@@ -158,7 +159,7 @@ def test_cross_stacking(base_dir: str):
     )
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-3)
 
@@ -184,7 +185,7 @@ def test_fene(base_dir: str):
     )
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-6)
 
@@ -235,7 +236,7 @@ def test_hydrogen_bonding(base_dir: str, weights_file: str, *, use_pseq: bool, t
         energy_fn = energy_fn.with_params(pseq=pseq, pseq_constraints=sc)
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-3)
 
@@ -288,7 +289,7 @@ def test_stacking(base_dir: str, weights_file: str, *, use_pseq: bool):
         energy_fn = energy_fn.with_params(pseq=pseq, pseq_constraints=sc)
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
 
     np.testing.assert_allclose(energy, terms, atol=1e-6)
@@ -315,7 +316,7 @@ def test_unbonded_excluded_volume(base_dir: str):
     )
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-6)
 
@@ -383,7 +384,7 @@ def test_total_energy(base_dir: str, t_kelvin: float, *, use_neighbors: bool):
 
     energy_fn = jd_energy_base.ComposedEnergyFunction(energy_fns=transformed_fns)
 
-    energies = energy_fn.map(states)
+    energies = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
 
     energies = np.around(energies / topology.n_nucleotides, 6)
 

--- a/mythos/energy/dna2/nucleotide.py
+++ b/mythos/energy/dna2/nucleotide.py
@@ -4,7 +4,7 @@ import chex
 import jax_md
 
 import mythos.energy.base as je_base
-import mythos.energy.utils as je_utils
+import mythos.utils.math as ju_math
 import mythos.utils.types as typ
 
 
@@ -36,9 +36,9 @@ class Nucleotide(je_base.BaseNucleotide):
         com_to_stacking: typ.Scalar,
     ) -> "Nucleotide":
         """Class method to precompute nucleotide sites from a rigid body."""
-        back_base_vectors = je_utils.q_to_back_base(rigid_body.orientation)
-        base_normals = je_utils.q_to_base_normal(rigid_body.orientation)
-        cross_prods = je_utils.q_to_cross_prod(rigid_body.orientation)
+        back_base_vectors = ju_math.q_to_back_base(rigid_body.orientation)
+        base_normals = ju_math.q_to_base_normal(rigid_body.orientation)
+        cross_prods = ju_math.q_to_cross_prod(rigid_body.orientation)
 
         stack_sites = rigid_body.center + com_to_stacking * back_base_vectors
         back_sites = rigid_body.center + com_to_backbone_x * back_base_vectors + com_to_backbone_y * cross_prods

--- a/mythos/energy/dna2/tests/test_integration.py
+++ b/mythos/energy/dna2/tests/test_integration.py
@@ -9,6 +9,7 @@ import pytest
 import mythos.energy.dna2 as jd_energy
 import mythos.input.topology as jd_top
 import mythos.input.trajectory as jd_traj
+import mythos.simulators.io as jd_sio
 from mythos.input.sequence_constraints import dseq_to_pseq, from_bps
 from mythos.utils.units import get_kt
 
@@ -91,7 +92,7 @@ def test_fene(base_dir: str):
     )
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-6)
 
@@ -117,7 +118,7 @@ def test_bonded_excluded_volume(base_dir: str):
     )
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-6)
 
@@ -158,7 +159,7 @@ def test_stacking(base_dir: str, t_kelvin: float, weights: jnp.ndarray, *, use_p
         energy_fn = energy_fn.with_params(pseq=pseq, pseq_constraints=sc)
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     if weights is not None:
         terms *= 0.0  # our supplied weights are zero, so we expect zero energy
@@ -187,7 +188,7 @@ def test_cross_stacking(base_dir: str):
     )
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-3)
 
@@ -213,7 +214,7 @@ def test_unbonded_excluded_volume(base_dir: str):
     )
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-6)
 
@@ -239,7 +240,7 @@ def test_hydrogen_bonding(base_dir: str):
     )
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-3)
 
@@ -265,7 +266,7 @@ def test_coaxial_stacking(base_dir: str):
     )
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-6)
 
@@ -308,7 +309,7 @@ def test_debye(base_dir: str, t_kelvin: float, salt_conc: float, *, half_charged
     )
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-3)
 
@@ -375,7 +376,7 @@ def test_total_energy(base_dir: str, *, half_charged_ends: bool):
     )
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-3)
 

--- a/mythos/energy/na1/tests/test_integration.py
+++ b/mythos/energy/na1/tests/test_integration.py
@@ -11,6 +11,7 @@ import mythos.energy.na1 as jd_energy
 import mythos.input.toml as jd_toml
 import mythos.input.topology as jd_top
 import mythos.input.trajectory as jd_traj
+import mythos.simulators.io as jd_sio
 
 jax.config.update("jax_enable_x64", True)  # noqa: FBT003 - ignore boolean positional value
 # this is a common jax practice
@@ -182,7 +183,7 @@ def test_fene(base_dir: str):
 
     states = trajectory.state_rigid_body
 
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
 
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-6)
@@ -223,7 +224,7 @@ def test_bonded_excluded_volume(base_dir: str):
 
     states = trajectory.state_rigid_body
 
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
 
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-6)
@@ -269,7 +270,7 @@ def test_stacking(base_dir: str, t_kelvin: float, weights: jnp.ndarray):
 
     states = trajectory.state_rigid_body
 
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
 
     energy = np.around(energy / topology.n_nucleotides, 6)
 
@@ -313,7 +314,7 @@ def test_unbonded_excluded_volume(base_dir: str):
         params=energy_config.init_params(),
     )
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-6)
 
@@ -352,7 +353,7 @@ def test_cross_stacking(base_dir: str):
         params=energy_config.init_params(),
     )
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-4)  # using a higher tolerance here
 
@@ -391,7 +392,7 @@ def test_hydrogen_bonding(base_dir: str):
         params=energy_config.init_params(),
     )
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-4)  # using a higher tolerance here
 
@@ -431,7 +432,7 @@ def test_coaxial_stacking(base_dir: str):
         params=energy_config.init_params(),
     )
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-6)
 
@@ -484,7 +485,7 @@ def test_debye(base_dir: str, t_kelvin: float, salt_conc: float, *, half_charged
         params=energy_config.init_params(),
     )
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-5)
 

--- a/mythos/energy/rna2/nucleotide.py
+++ b/mythos/energy/rna2/nucleotide.py
@@ -4,7 +4,7 @@ import chex
 import jax_md
 
 import mythos.energy.base as je_base
-import mythos.energy.utils as je_utils
+import mythos.utils.math as ju_math
 import mythos.utils.types as typ
 
 
@@ -48,9 +48,9 @@ class Nucleotide(je_base.BaseNucleotide):
         pos_stack_5_a2: typ.Scalar,
     ) -> "Nucleotide":
         """Class method to precompute nucleotide sites from a rigid body."""
-        back_base_vectors = je_utils.q_to_back_base(rigid_body.orientation)
-        base_normals = je_utils.q_to_base_normal(rigid_body.orientation)
-        cross_prods = je_utils.q_to_cross_prod(rigid_body.orientation)
+        back_base_vectors = ju_math.q_to_back_base(rigid_body.orientation)
+        base_normals = ju_math.q_to_base_normal(rigid_body.orientation)
+        cross_prods = ju_math.q_to_cross_prod(rigid_body.orientation)
 
         back_sites = rigid_body.center + com_to_backbone_x * back_base_vectors + com_to_backbone_y * base_normals
         stack_sites = rigid_body.center + com_to_stacking * back_base_vectors

--- a/mythos/energy/rna2/tests/test_integration.py
+++ b/mythos/energy/rna2/tests/test_integration.py
@@ -12,6 +12,7 @@ import mythos.energy.rna2 as jd_energy
 import mythos.input.toml as jd_toml
 import mythos.input.topology as jd_top
 import mythos.input.trajectory as jd_traj
+import mythos.simulators.io as jd_sio
 from mythos.input.sequence_constraints import dseq_to_pseq, from_bps
 
 jax.config.update("jax_enable_x64", True)  # noqa: FBT003 - ignore boolean positional value
@@ -103,7 +104,7 @@ def test_fene(base_dir: str):
     )
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-6)
 
@@ -129,7 +130,7 @@ def test_bonded_excluded_volume(base_dir: str):
     )
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-6)
 
@@ -169,7 +170,7 @@ def test_stacking(base_dir: str, t_kelvin: float, weights: jnp.ndarray, *, use_p
         energy_fn = energy_fn.with_params(pseq=pseq, pseq_constraints=sc)
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     if weights is not None:
         terms *= 0.0  # our supplied weights are zero, so we expect zero energy
@@ -197,7 +198,7 @@ def test_unbonded_excluded_volume(base_dir: str):
     )
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-6)
 
@@ -223,7 +224,7 @@ def test_hydrogen_bonding(base_dir: str):
     )
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-3)
 
@@ -250,7 +251,7 @@ def test_cross_stacking(base_dir: str):
     )
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-3)
 
@@ -282,7 +283,7 @@ def test_coaxial_stacking(base_dir: str):
     )
 
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-6)
 
@@ -323,7 +324,7 @@ def test_debye(base_dir: str, t_kelvin: float, salt_conc: float, *, half_charged
         params=energy_config.init_params(),
     )
     states = trajectory.state_rigid_body
-    energy = energy_fn.map(states)
+    energy = energy_fn.map(jd_sio.SimulatorTrajectory(rigid_body=states))
     energy = np.around(energy / topology.n_nucleotides, 6)
     np.testing.assert_allclose(energy, terms, atol=1e-3)
 

--- a/mythos/energy/tests/test_base.py
+++ b/mythos/energy/tests/test_base.py
@@ -13,6 +13,7 @@ import pytest
 
 from mythos.energy import base
 from mythos.energy.configuration import BaseConfiguration
+from mythos.simulators.io import SimulatorTrajectory
 
 NOT_IMPLEMENTED_ERR = re.compile("unsupported operand type\(s\) for")  # noqa: W605 - Ignore the regex warning
 
@@ -245,7 +246,7 @@ class MockEnergyFunction(base.BaseEnergyFunction):
 @pytest.mark.parametrize(
     ("rigid_body_transform_fn", "expected"),
     [
-        (None, 4.0),
+        (lambda x: x, 4.0),
         (lambda x: jax_md.rigid_body.RigidBody(center=x.center * 2, orientation=x.orientation), 8.0),
     ],
 )
@@ -264,7 +265,7 @@ def test_ComposedEnergyFunction_call(
         orientation=jnp.array([[1.0, 1.0], [1.0, 1.0]]),
     )
 
-    assert cef(body) == expected
+    assert cef(SimulatorTrajectory(rigid_body=body)) == expected
 
 
 @pytest.fixture

--- a/mythos/energy/utils.py
+++ b/mythos/energy/utils.py
@@ -5,7 +5,6 @@ import importlib
 
 import jax
 import jax.numpy as jnp
-import jax_md
 import numpy as np
 from jax import vmap
 from jaxtyping import PyTree
@@ -13,27 +12,6 @@ from jaxtyping import PyTree
 import mythos.utils.constants as jd_const
 import mythos.utils.types as typ
 from mythos.input import toml
-
-
-@vmap
-def q_to_back_base(q: jax_md.rigid_body.Quaternion) -> jnp.ndarray:
-    """Get the vector from the center to the base of the nucleotide."""
-    q0, q1, q2, q3 = q.vec
-    return jnp.array([q0**2 + q1**2 - q2**2 - q3**2, 2 * (q1 * q2 + q0 * q3), 2 * (q1 * q3 - q0 * q2)])
-
-
-@vmap
-def q_to_base_normal(q: jax_md.rigid_body.Quaternion) -> jnp.ndarray:
-    """Get the normal vector to the base of the nucleotide."""
-    q0, q1, q2, q3 = q.vec
-    return jnp.array([2 * (q1 * q3 + q0 * q2), 2 * (q2 * q3 - q0 * q1), q0**2 - q1**2 - q2**2 + q3**2])
-
-
-@vmap
-def q_to_cross_prod(q: jax_md.rigid_body.Quaternion) -> jnp.ndarray:
-    """Get the cross product vector of the nucleotide."""
-    q0, q1, q2, q3 = q.vec
-    return jnp.array([2 * (q1 * q2 - q0 * q3), q0**2 - q1**2 + q2**2 - q3**2, 2 * (q2 * q3 + q0 * q1)])
 
 
 @functools.partial(vmap, in_axes=(None, 0, 0), out_axes=0)

--- a/mythos/observables/melting_temp.py
+++ b/mythos/observables/melting_temp.py
@@ -123,12 +123,11 @@ class MeltingTemp(jd_obs.BaseObservable):
         opt_params: jd_types.PyTree,
     ) -> float:
         """Calculate the bound:unbound ratios at the extrapolated temperatures."""
-        energies_t0 = self.energy_fn.with_params(opt_params).map(trajectory.rigid_body)
+        energies_t0 = self.energy_fn.with_params(opt_params).map(trajectory)
 
         # find the unbiased ratio of bound:unbound across the temperature range
         def finf_at_t(extrapolated_temp: float) -> float:
-            energies_tx = self.energy_fn.with_params(opt_params, kt=extrapolated_temp).map(trajectory.rigid_body)
-
+            energies_tx = self.energy_fn.with_params(opt_params, kt=extrapolated_temp).map(trajectory)
             boltz_factor = jnp.exp((energies_t0/self.sim_temperature) - (energies_tx/extrapolated_temp))
             unbiased_counts = (1 / umbrella_weights) * boltz_factor
             total_unbound = jnp.where(bind_states == 0, unbiased_counts, 0).sum()

--- a/mythos/optimization/objective.py
+++ b/mythos/optimization/objective.py
@@ -192,7 +192,7 @@ def compute_loss(
         size and the measured value of the trajectory, and the new energies.
     """
     energy_fn = energy_fn.with_params(opt_params)
-    new_energies = energy_fn.map(ref_states.rigid_body)
+    new_energies = energy_fn.map(ref_states)
     weights, neff = compute_weights_and_neff(
         beta,
         new_energies,
@@ -288,12 +288,12 @@ class DiffTReObjective(Objective):
         # within neff tolerance (or max_valid_opt_steps). These params are then
         # used to compute reference energies.
         reference_opt_params = reference_opt_params or opt_params
-        reference_energies = self.energy_fn.with_params(reference_opt_params).map(reference_states.rigid_body)
+        reference_energies = self.energy_fn.with_params(reference_opt_params).map(reference_states)
 
         # Compute neff to check if trajectory is still valid
         _, neff = compute_weights_and_neff(
             beta=self.beta,
-            new_energies=self.energy_fn.with_params(opt_params).map(reference_states.rigid_body),
+            new_energies=self.energy_fn.with_params(opt_params).map(reference_states),
             ref_energies=reference_energies,
         )
 

--- a/mythos/optimization/tests/test_objective.py
+++ b/mythos/optimization/tests/test_objective.py
@@ -35,7 +35,7 @@ def make_mock_energy_fn(return_value = None) -> EnergyFunction:
         def map(self, n):
             if return_value is not None:
                 return return_value
-            return jnp.array(n.center)
+            return jnp.array(n.rigid_body.center)
 
         def with_params(self, *_args, **_kwargs):
             return self
@@ -232,7 +232,7 @@ def test_compute_loss(
     """Test the loss calculation in for a Difftre Objective."""
     expected_aux = (np.array(1.0), expected_measured_value, np.array([1, 2, 3]))
     loss_fn = mock_return_function((expected_loss, (expected_measured_value, {})))
-    ref_energies = mock_energy_fn.map(ref_energies.rigid_body)
+    ref_energies = mock_energy_fn.map(ref_energies)
 
     loss, aux = o.compute_loss(opt_params, mock_energy_fn, beta, loss_fn, ref_states, ref_energies, observables=[])
 

--- a/mythos/simulators/io.py
+++ b/mythos/simulators/io.py
@@ -9,8 +9,8 @@ import jax.numpy as jnp
 import jax_md
 from typing_extensions import override
 
-from mythos.energy.utils import q_to_back_base, q_to_base_normal
 from mythos.input.trajectory import _write_state
+from mythos.utils.math import q_to_back_base, q_to_base_normal
 from mythos.utils.types import Vector3D
 
 
@@ -25,11 +25,6 @@ class SimulatorTrajectory:
     def __post_init__(self) -> None:
         if self.metadata is None:
             self.metadata = [None] * self.rigid_body.center.shape[0]
-        if len(self.metadata) != self.rigid_body.center.shape[0]:
-            raise ValueError(
-                f"Metadata length {len(self.metadata)} does not match "
-                f"trajectory length {self.rigid_body.center.shape[0]}"
-            )
 
     def with_state_metadata(self, metadata: Any) -> "SimulatorTrajectory":
         """Set the same metadata for all states in the trajectory."""

--- a/mythos/simulators/lammps/tests/test_lammps_oxdna.py
+++ b/mythos/simulators/lammps/tests/test_lammps_oxdna.py
@@ -480,7 +480,7 @@ def test_lammps_energy():
         displacement_fn=jax_md.space.periodic(200)[0]
     ).without_terms("BondedExcludedVolume"  # lammps doesn't do this term
     ).with_params(kt = 0.1)
-    energy = energy_fn.map(sim_traj.rigid_body)
+    energy = energy_fn.map(sim_traj)
 
     # lammps will report per-nucleotide energy
     energy_per_nucleotide = energy / topology.n_nucleotides
@@ -505,7 +505,7 @@ def test_lammps_energy_dna2():
         # is configurable there.
         kt = 0.1, salt_conc=0.5, q_eff=0.815, half_charged_ends=False
     )
-    energy = energy_fn.map(sim_traj.rigid_body)
+    energy = energy_fn.map(sim_traj)
 
     # lammps will report per-nucleotide energy
     energy_per_nucleotide = energy / topology.n_nucleotides

--- a/mythos/simulators/tests/test_io.py
+++ b/mythos/simulators/tests/test_io.py
@@ -204,22 +204,3 @@ def test_simulatortrajectory_filter_preserves_data() -> None:
     assert jnp.allclose(filtered_traj.rigid_body.center[0], jnp.array([1, 2, 3]))
     assert jnp.allclose(filtered_traj.rigid_body.center[1], jnp.array([7, 8, 9]))
 
-
-@pytest.mark.parametrize(
-    ("n_states", "n_md"),
-    [
-        (5, 3),
-        (8, 1),
-    ],
-)
-def test_simulatortrajectory_errors_on_wrong_metadata_shape(n_states, n_md) -> None:
-    with pytest.raises(ValueError, match="does not match trajectory length"):
-        jd_sio.SimulatorTrajectory(
-            rigid_body=jax_md.rigid_body.RigidBody(
-                center=jnp.zeros((n_states, 3)),
-                orientation=jax_md.rigid_body.Quaternion(
-                    vec=jnp.zeros((n_states, 4)),
-                ),
-            ),
-            metadata=[{"value": i} for i in range(n_md)],
-        )

--- a/mythos/utils/math.py
+++ b/mythos/utils/math.py
@@ -1,9 +1,32 @@
 """Math utilities for DNA sequence analysis."""
 
 import jax.numpy as jnp
+import jax_md
 import numpy as np
+from jax import vmap
 
 import mythos.utils.types as typ
+
+
+@vmap
+def q_to_back_base(q: jax_md.rigid_body.Quaternion) -> jnp.ndarray:
+    """Get the vector from the center to the base of the nucleotide."""
+    q0, q1, q2, q3 = q.vec
+    return jnp.array([q0**2 + q1**2 - q2**2 - q3**2, 2 * (q1 * q2 + q0 * q3), 2 * (q1 * q3 - q0 * q2)])
+
+
+@vmap
+def q_to_base_normal(q: jax_md.rigid_body.Quaternion) -> jnp.ndarray:
+    """Get the normal vector to the base of the nucleotide."""
+    q0, q1, q2, q3 = q.vec
+    return jnp.array([2 * (q1 * q3 + q0 * q2), 2 * (q2 * q3 - q0 * q1), q0**2 - q1**2 - q2**2 + q3**2])
+
+
+@vmap
+def q_to_cross_prod(q: jax_md.rigid_body.Quaternion) -> jnp.ndarray:
+    """Get the cross product vector of the nucleotide."""
+    q0, q1, q2, q3 = q.vec
+    return jnp.array([2 * (q1 * q2 - q0 * q3), q0**2 - q1**2 + q2**2 - q3**2, 2 * (q2 * q3 + q0 * q1)])
 
 
 def principal_axes_to_euler_angles(


### PR DESCRIPTION
This change is in preparation for the martini energy function which need a per-state box_size to be accessible. The data must be passed in to the energy function call with the trajectory due to the DiffTre/Objective and optimization APIs. 

In this change we assume that `BaseEnergyFunction` is DNA specific so that its `__call__` signature can take `Nucleotide` as before and that it explicitly passes the `.rigid_body` component to the `transform_fn`. To contain scope, we do not change the `transform_fn` call signature and we keep `BaseEnergyFunction` mostly intact (e.g. not generic for upcoming martini).

Notes:
* Always call `transform_fn` (does it makes sense not to when most if not all energy functions use nucleotide data members?)
* Bug fix in jax_md post_init
* Update jax_md example script - mostly because it looks like we don't have tests for this
* to work around a circular import (introduced due to new dep on SimTraj), move `q_to_*` functions to math module
* Need to remove post_init check in simulatorTraj to be vmap compatible. This change is closely related to #63, but not a hard dependency. Conflict should be simple.
