### PR TITLE
do not capture simulators/objectives in remote, pass as data

### DIFF
--- a/mythos/optimization/optimization.py
+++ b/mythos/optimization/optimization.py
@@ -256,7 +256,7 @@ class RayOptimizer(Optimizer):
         ref_map, grads_completed, output_observables = {}, {}, {}
 
         # schedule all objectives that already have their observables in state
-        while needed_objectives := set(obj_lookup) - set(grads_completed):
+        while (needed_objectives := set(obj_lookup) - set(grads_completed)) or ref_map:
             for obj_name in needed_objectives:
                 objective = obj_lookup[obj_name]
                 # skip if we are currently running it

--- a/mythos/optimization/optimization.py
+++ b/mythos/optimization/optimization.py
@@ -12,6 +12,7 @@ import jax.numpy as jnp
 import optax
 import ray
 from ray import ObjectRef as RayRef
+from ray.remote_function import RemoteFunction
 from typing_extensions import override
 
 from mythos.optimization.objective import Objective, ObjectiveOutput
@@ -146,6 +147,28 @@ class Optimizer(ABC):
         return output
 
 
+# Helper functions for running remote tasks
+@ray.remote
+def _simulator_run_fn(simulator: Simulator, params: Params, state: dict[str, Any]) -> tuple[list[RayRef], RayRef]:
+    output = simulator.run(opt_params=params, **state)
+    return *output.observables, output.state
+
+
+@ray.remote
+def _objective_compute_fn(
+    objective: Objective, obs: dict[str, RayRef], params: Params, state: dict[str, Any]
+) -> ObjectiveOutput:
+    # Since ray won't unpack nested refs automatically, we do so since we can
+    # guarantee the shape of the object
+    obs = {k: ray.get(v) for k, v in obs.items()}
+    return objective.calculate(observables=obs, opt_params=params, **state)
+
+
+# This indirection helps with mocking in testing
+def _create_and_run_remote(fun: RemoteFunction, ray_options: dict, *args) -> RayRef | list[RayRef]:
+    return fun.options(**ray_options).remote(*args)
+
+
 @chex.dataclass(frozen=True, kw_only=True)
 class RayOptimizer(Optimizer):
     """Optimization of a list of objectives using a list of simulators.
@@ -189,10 +212,6 @@ class RayOptimizer(Optimizer):
         if len(all_names) != len(set(all_names)):
             raise ValueError("All objective, simulator, and exposes names must be unique")
 
-    def _create_and_run_remote(self, fun: callable, ray_options: dict, *args) -> RayRef | list[RayRef]:
-        remote_fun = ray.remote(fun).options(**ray_options)
-        return remote_fun.remote(*args)
-
     def _get_ray_options(self, unit: SchedulerUnit) -> dict[str, Any]:
         options = {}
         if unit_hints := getattr(unit, "scheduler_hints", None):
@@ -202,28 +221,20 @@ class RayOptimizer(Optimizer):
         return {**self.remote_options_default, **options}
 
     def _run_simulator(self, simulator: Simulator, params: Params, **state) -> tuple[list[RayRef], RayRef]:
-        def simulator_run_fn(params: Params, state: dict[str, Any]) -> tuple[list[RayRef], RayRef]:
-            output = simulator.run(opt_params=params, **state)
-            return *output.observables, output.state
-
         ray_opts = {
             **self._get_ray_options(simulator),
             "name": "simulator_run:" + simulator.name,
             "num_returns": 1 + len(simulator.exposes()),
         }
-        refs = self._create_and_run_remote(simulator_run_fn, ray_opts, params, state)
+        refs = _create_and_run_remote(_simulator_run_fn, ray_opts, simulator, params, state)
         return refs[:-1], refs[-1]  # observables as a list, state
 
     def _run_objective(self, objective: Objective, observables: dict[str, RayRef], params: Params, **state) -> RayRef:
-        def objective_compute_fn(obs: dict[str, RayRef], params: Params, state: dict[str, Any]) -> ObjectiveOutput:
-            obs = {k: ray.get(v) for k, v in obs.items()}
-            return objective.calculate(observables=obs, opt_params=params, **state)
-
         ray_opts = {
             **self._get_ray_options(objective),
             "name": "objective_compute:" + objective.name,
         }
-        return self._create_and_run_remote(objective_compute_fn, ray_opts, observables, params, state)
+        return _create_and_run_remote(_objective_compute_fn, ray_opts, objective, observables, params, state)
 
     def _wait_remotes(self, refs: list[RayRef]) -> list[RayRef]:
         ref_list = list(refs)

--- a/mythos/optimization/tests/test_optimization.py
+++ b/mythos/optimization/tests/test_optimization.py
@@ -109,7 +109,7 @@ def _mock_ray(monkeypatch, request):  # mocks for ray infrastructure
     def mock_ray_get(ref):
         return ref.value
 
-    def mock_create_and_run_remote(_self, fun, ray_options, *args):
+    def mock_create_and_run_remote(fun, ray_options, *args):
         result = fun(*args)
         # Handle multi-return case (num_returns > 1)
         num_returns = ray_options.get("num_returns", 1)
@@ -117,13 +117,19 @@ def _mock_ray(monkeypatch, request):  # mocks for ray infrastructure
             return [MockRef(r) for r in result]
         return MockRef(result)
 
+    def mock_sim_run_fun(simulator, params, state):
+        out = simulator.run(opt_params=params, **state)
+        return *out.observables, out.state
+
+    def mock_objective_compute_fun(objective, obs, params, state):
+        obs = {k: mock_ray_get(v) for k, v in obs.items()}
+        return objective.calculate(observables=obs, opt_params=params, **state)
+
     monkeypatch.setattr("mythos.optimization.optimization.ray.wait", StatefulWaiter())
     monkeypatch.setattr("mythos.optimization.optimization.ray.get", mock_ray_get)
-    monkeypatch.setattr(
-        jdna_optimization.RayOptimizer,
-        "_create_and_run_remote",
-        mock_create_and_run_remote,
-    )
+    monkeypatch.setattr("mythos.optimization.optimization._create_and_run_remote", mock_create_and_run_remote)
+    monkeypatch.setattr("mythos.optimization.optimization._simulator_run_fn", mock_sim_run_fun)
+    monkeypatch.setattr("mythos.optimization.optimization._objective_compute_fn", mock_objective_compute_fun)
 
 
 # =============================================================================
@@ -652,15 +658,14 @@ class TestRayOptimizerSchedulerHints:
         """Track ray options passed to _create_and_run_remote."""
         captured_options = []
 
-        original_create_and_run = jdna_optimization.RayOptimizer._create_and_run_remote
+        original_create_and_run = jdna_optimization._create_and_run_remote
 
-        def tracking_create_and_run(self, fun, ray_options, *args):
+        def tracking_create_and_run(fun, ray_options, *args):
             captured_options.append(ray_options.copy())
-            return original_create_and_run(self, fun, ray_options, *args)
+            return original_create_and_run(fun, ray_options, *args)
 
         monkeypatch.setattr(
-            jdna_optimization.RayOptimizer,
-            "_create_and_run_remote",
+            "mythos.optimization.optimization._create_and_run_remote",
             tracking_create_and_run,
         )
         return captured_options

--- a/mythos/optimization/tests/test_optimization_ray_integration.py
+++ b/mythos/optimization/tests/test_optimization_ray_integration.py
@@ -1,0 +1,161 @@
+"""Integration tests that use a real (local) Ray session."""
+
+from dataclasses import field
+
+import chex
+import jax.numpy as jnp
+import optax
+import pytest
+import ray
+from typing_extensions import override
+
+import mythos.optimization.objective as jdna_objective
+import mythos.optimization.optimization as jdna_optimization
+from mythos.simulators.base import Simulator, SimulatorOutput
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _ray_session():
+    """Start a minimal local Ray session for the module and shut it down after."""
+    ray.init(num_cpus=2, log_to_driver=False)
+    yield
+    ray.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Minimal mock components (must be picklable for Ray serialization)
+# ---------------------------------------------------------------------------
+
+
+@chex.dataclass(frozen=True, kw_only=True)
+class RayMockSimulator(Simulator):
+    name: str = "ray_sim"
+    return_observables: list[jnp.ndarray] = field(default_factory=lambda: [jnp.array([1.0, 2.0])])
+    exposed_observables: list[str] = field(default_factory=lambda: ["trajectory"])
+
+    @override
+    def run(self, *_args, opt_params, **state) -> SimulatorOutput:
+        return SimulatorOutput(
+            observables=self.return_observables,
+            state={"call_count": state.get("call_count", 0) + 1},
+        )
+
+    def exposes(self) -> list[str]:
+        return self.exposed_observables
+
+
+@chex.dataclass(frozen=True, kw_only=True)
+class RayMockObjective(jdna_objective.Objective):
+    @override
+    def calculate(self, observables, opt_params, **state):
+        obs = next(iter(observables.values()))
+        grads = {k: v * 0.1 for k, v in opt_params.items()}
+        return jdna_objective.ObjectiveOutput(
+            is_ready=True,
+            state={"call_count": state.get("call_count", 0) + 1},
+            observables={"total": obs.sum()},
+            grads=grads,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRayIntegration:
+    """Tests that exercise the real Ray remote machinery."""
+
+    def test_single_step_through_ray(self):
+        """A single optimisation step runs end-to-end via Ray remotes."""
+        simulator = RayMockSimulator()
+        objective = RayMockObjective(
+            name="ray_obj",
+            required_observables=tuple(simulator.exposes()),
+            grad_or_loss_fn=lambda x: x,
+        )
+
+        opt = jdna_optimization.RayOptimizer(
+            objectives=[objective],
+            simulators=[simulator],
+            aggregate_grad_fn=lambda grads: grads[0] if grads else {},
+            optimizer=optax.sgd(0.01),
+        )
+
+        params = {"p": jnp.array(1.0)}
+        output = opt.step(params=params)
+
+        assert isinstance(output, jdna_optimization.OptimizerOutput)
+        assert output.opt_params is not None
+        assert output.grads is not None
+        # SGD: new = old - lr * grad;  grad = 0.1 * 1.0 = 0.1
+        assert jnp.allclose(output.opt_params["p"], 1.0 - 0.01 * 0.1)
+        # observable recorded
+        assert "ray_obj" in output.observables
+        assert float(output.observables["ray_obj"]["total"]) == 3.0  # 1+2
+
+    def test_multi_step_state_persists_through_ray(self):
+        """State flows correctly across two consecutive Ray-backed steps."""
+        simulator = RayMockSimulator()
+        objective = RayMockObjective(
+            name="ray_obj",
+            required_observables=tuple(simulator.exposes()),
+            grad_or_loss_fn=lambda x: x,
+        )
+
+        opt = jdna_optimization.RayOptimizer(
+            objectives=[objective],
+            simulators=[simulator],
+            aggregate_grad_fn=lambda grads: grads[0] if grads else {},
+            optimizer=optax.sgd(0.01),
+        )
+
+        params = {"p": jnp.array(5.0)}
+        out1 = opt.step(params=params)
+        out2 = opt.step(params=out1.opt_params, state=out1.state)
+
+        # Params should have been updated twice
+        assert not jnp.allclose(out1.opt_params["p"], out2.opt_params["p"])
+        # Optimizer state preserved
+        assert out2.state.optimizer_state is not None
+        # Component states carried forward
+        assert out2.state.component_state["ray_obj"]["call_count"] >= 1
+        assert out2.state.component_state["ray_sim"]["call_count"] >= 1
+
+    def test_multiple_simulators_and_objectives_through_ray(self):
+        """Two simulator / objective pairs coordinate correctly via Ray."""
+        sim1 = RayMockSimulator(
+            name="sim_a",
+            return_observables=[jnp.array([10.0])],
+            exposed_observables=["obs_a"],
+        )
+        sim2 = RayMockSimulator(
+            name="sim_b",
+            return_observables=[jnp.array([20.0])],
+            exposed_observables=["obs_b"],
+        )
+        obj1 = RayMockObjective(
+            name="obj_a",
+            required_observables=("obs_a",),
+            grad_or_loss_fn=lambda x: x,
+        )
+        obj2 = RayMockObjective(
+            name="obj_b",
+            required_observables=("obs_b",),
+            grad_or_loss_fn=lambda x: x,
+        )
+
+        opt = jdna_optimization.RayOptimizer(
+            objectives=[obj1, obj2],
+            simulators=[sim1, sim2],
+            aggregate_grad_fn=lambda grads: {k: sum(g[k] for g in grads) / len(grads) for k in grads[0]},
+            optimizer=optax.sgd(0.01),
+        )
+
+        params = {"p": jnp.array(1.0)}
+        output = opt.step(params=params)
+
+        assert "obj_a" in output.observables
+        assert "obj_b" in output.observables
+        assert float(output.observables["obj_a"]["total"]) == 10.0
+        assert float(output.observables["obj_b"]["total"]) == 20.0

--- a/mythos/optimization/tests/test_optimization_ray_integration.py
+++ b/mythos/optimization/tests/test_optimization_ray_integration.py
@@ -17,7 +17,7 @@ from mythos.simulators.base import Simulator, SimulatorOutput
 @pytest.fixture(scope="module", autouse=True)
 def _ray_session():
     """Start a minimal local Ray session for the module and shut it down after."""
-    ray.init(num_cpus=2, log_to_driver=False)
+    ray.init(num_cpus=2, log_to_driver=False, local_mode=True)
     yield
     ray.shutdown()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,6 @@ lint.select = ["ALL"]
 lint.ignore = [
     "ANN002",  # https://docs.astral.sh/ruff/rules/missing-type-args/
     "ANN003",  # https://docs.astral.sh/ruff/rules/missing-type-kwargs/
-    "ANN101",  # https://docs.astral.sh/ruff/rules/missing-type-self/
-    "ANN102",  # https://docs.astral.sh/ruff/rules/missing-type-cls/
     "ANN401",  # https://docs.astral.sh/ruff/rules/any-type/
     "PLR0913",  # https://docs.astral.sh/ruff/rules/too-many-arguments/
     "EM101",  # https://docs.astral.sh/ruff/rules/raw-string-in-exception/


### PR DESCRIPTION
This change resolves the warnings about large remote function size, which was caused by the capture of the simulator/objective within the closure. Here we define the remote functions at the module level and pass simulators/objectives as remote data, which fits ray's model better and is also more efficient than creating the remote functions on each invocation.

**Notes**: 
* I chose not to cache the sim/obj remote references so they do not inadvertently outlive the use of the optimizer even when a reference is kept around, and because it would violate the stateless nature.
* Added some integration test that actually run through the ray remote path - these were missing from the previous version, and seemed to have uncovered a 🐞 (we didn't always flush all remotes, e.g. simulator state)

Resolves #84 