### PR TITLE
add util function and script for preprocessing topology

### DIFF
--- a/examples/gromacs_prep.py
+++ b/examples/gromacs_prep.py
@@ -8,15 +8,14 @@ an archive location before preprocessing.
 
 Example usage::
 
-    python gromacs_prep.py /path/to/gromacs/input
-    python gromacs_prep.py /path/to/input --copy-to /path/to/archive
-    python gromacs_prep.py /path/to/input --gromacs-binary /usr/local/bin/gmx
-    python gromacs_prep.py /path/to/input --params nsteps=5000 dt=0.002
+    python examples/gromacs_prep.py /path/to/gromacs/input
+    python examples/gromacs_prep.py /path/to/input --copy-to /path/to/archive
+    python examples/gromacs_prep.py /path/to/input --gromacs-binary /usr/local/bin/gmx
+    python examples/gromacs_prep.py /path/to/input --params nsteps=5000 dt=0.002
 """
 
 import argparse
 import logging
-import sys
 
 from mythos.simulators.gromacs.utils import preprocess_topology
 

--- a/examples/gromacs_prep.py
+++ b/examples/gromacs_prep.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+"""Preprocess a GROMACS topology for use with mythos.
+
+This script wraps `preprocess_topology` so users can prepare their
+GROMACS input files from the command line without embedding the logic
+in their own scripts.  It optionally copies the input directory to
+an archive location before preprocessing.
+
+Example usage::
+
+    python gromacs_prep.py /path/to/gromacs/input
+    python gromacs_prep.py /path/to/input --copy-to /path/to/archive
+    python gromacs_prep.py /path/to/input --gromacs-binary /usr/local/bin/gmx
+    python gromacs_prep.py /path/to/input --params nsteps=5000 dt=0.002
+"""
+
+import argparse
+import logging
+import sys
+
+from mythos.simulators.gromacs.utils import preprocess_topology
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def parse_params(param_strings: list[str] | None) -> dict[str, str]:
+    """Parse ``key=value`` strings into a dictionary."""
+    if not param_strings:
+        return {}
+    params: dict[str, str] = {}
+    for item in param_strings:
+        if "=" not in item:
+            raise SystemExit(f"Invalid parameter format '{item}'. Expected key=value.")
+        key, value = item.split("=", 1)
+        params[key.strip()] = value.strip()
+    return params
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Preprocess a GROMACS topology for use with mythos.",
+    )
+    parser.add_argument(
+        "input_dir",
+        help="Directory containing the GROMACS input files.",
+    )
+    parser.add_argument(
+        "--copy-to",
+        default=None,
+        help="Copy input files to this directory before preprocessing (useful for archiving).",
+    )
+    parser.add_argument(
+        "--output-prefix",
+        default="preprocessed",
+        help="Prefix for the preprocessed .top and .tpr files (default: preprocessed).",
+    )
+    parser.add_argument(
+        "--output-mdp-name",
+        default="preprocessed.mdp",
+        help="Name of the output .mdp file (default: preprocessed.mdp).",
+    )
+    parser.add_argument(
+        "--gromacs-binary",
+        default=None,
+        help="Path to the GROMACS binary (default: gmx on PATH).",
+    )
+    parser.add_argument(
+        "--mdp-name",
+        default="md.mdp",
+        help="Name of the .mdp file in the input directory (default: md.mdp).",
+    )
+    parser.add_argument(
+        "--topology-name",
+        default="topol.top",
+        help="Name of the topology file (default: topol.top).",
+    )
+    parser.add_argument(
+        "--structure-name",
+        default="membrane.gro",
+        help="Name of the structure file (default: membrane.gro).",
+    )
+    parser.add_argument(
+        "--index-name",
+        default="index.ndx",
+        help="Name of the index file (default: index.ndx).",
+    )
+    parser.add_argument(
+        "--params",
+        nargs="*",
+        metavar="KEY=VALUE",
+        help="MDP parameter overrides, e.g. --params nsteps=5000 dt=0.002",
+    )
+    parser.add_argument(
+        "--log-prefix",
+        default="topology_preprocess",
+        help="Prefix for log messages (default: topology_preprocess).",
+    )
+
+    args = parser.parse_args(argv)
+    params = parse_params(args.params)
+
+    logger.info("Preprocessing topology in %s", args.input_dir)
+    if args.copy_to:
+        logger.info("Archiving input to %s", args.copy_to)
+    if params:
+        logger.info("MDP overrides: %s", params)
+
+    preprocess_topology(
+        input_dir=args.input_dir,
+        params=params or None,
+        copy_to=args.copy_to,
+        output_prefix=args.output_prefix,
+        output_mdp_name=args.output_mdp_name,
+        gromacs_binary=args.gromacs_binary,
+        mdp_name=args.mdp_name,
+        topology_name=args.topology_name,
+        structure_name=args.structure_name,
+        index_name=args.index_name,
+        log_prefix=args.log_prefix,
+    )
+
+    logger.info("Done. Preprocessed files written to %s", args.copy_to or args.input_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/mythos/observables/wasserstein.py
+++ b/mythos/observables/wasserstein.py
@@ -33,7 +33,7 @@ def wasserstein_1d(u: Arr_N, v: Arr_N, u_weights: Arr_N | None = None, v_weights
         raise ValueError(f"v_weights must have the same shape as v; got {v_weights.shape} and {v.shape}.")
 
     # Validate that total masses match (within numerical tolerance)
-    if not jnp.isclose(jnp.sum(u_weights), jnp.sum(v_weights), rtol=1e-9, atol=1e-12):
+    if not jnp.isclose(jnp.sum(u_weights), jnp.sum(v_weights), rtol=1e-5, atol=1e-5):
         raise ValueError(
             "u_weights and v_weights must sum to the same total mass; "
             f"got {jnp.sum(u_weights)} and {jnp.sum(v_weights)}."

--- a/mythos/simulators/gromacs/gromacs.py
+++ b/mythos/simulators/gromacs/gromacs.py
@@ -11,13 +11,13 @@ import jax.numpy as jnp
 import numpy as np
 
 from mythos.energy.base import EnergyFunction
-from mythos.input.gromacs_input import read_mdp, replace_params_in_topology, update_mdp_params
+from mythos.input.gromacs_input import read_mdp, replace_params_in_topology
 from mythos.simulators import io as jd_sio
 from mythos.simulators.base import InputDirSimulator, SimulatorOutput
 from mythos.simulators.gromacs import utils as gromacs_utils
 from mythos.utils.helpers import run_command, try_to_float
 
-PREPROCESSED_TOPOLOGY_FILE = "_pp_topol.top"
+PREPROCESSED_PREFIX = "preprocessed"
 OUTPUT_PREFIX = "output"
 KB = 0.0083144621  # Boltzmann constant in kJ/(mol·K)
 
@@ -132,22 +132,14 @@ class GromacsSimulator(InputDirSimulator):
 
     def _run_simulation_step(self, structure_file: str, overrides: dict[str, Any], input_dir: Path, step: str) -> None:
         step_mdp = f"{step}_{self.mdp_file}"
-        update_mdp_params(input_dir / self.mdp_file, overrides, out_file=input_dir / step_mdp)
-        # prepare the run
-        cmd = [
-            "grompp",
-            "-f",
-            step_mdp,
-            "-c",
-            structure_file,
-            "-p",
-            PREPROCESSED_TOPOLOGY_FILE,  # created in _update_topology_params
-            "-n",
-            self.index_file,
-            "-o",
-            f"{OUTPUT_PREFIX}.tpr",
-        ]
-        self._run_gromacs(cmd, cwd=input_dir, log_prefix=f"{step}_grompp")
+        gromacs_utils.preprocess_topology(
+            input_dir=input_dir,
+            params=overrides,
+            structure_name=structure_file,
+            topology_name=f"{PREPROCESSED_PREFIX}.top",
+            output_prefix=OUTPUT_PREFIX,
+            output_mdp_name=step_mdp,
+        )
 
         # run the simulation
         cmd = [
@@ -189,23 +181,15 @@ class GromacsSimulator(InputDirSimulator):
     def _update_topology_params(self, input_dir: Path, params: dict[str, Any]) -> None:
         # ensure we start with a preprocessed topology, so create using grompp
         # which then will be used for writing replacement parameters.
-        preproc_mdp = f"preprocess_{self.mdp_file}"
-        update_mdp_params(input_dir / self.mdp_file, self.input_overrides, out_file=input_dir / preproc_mdp)
-        cmd = [
-            "grompp",
-            "-p",
-            self.topology_file,
-            "-f",
-            preproc_mdp,
-            "-c",
-            self.structure_file,
-            "-n",
-            self.index_file,
-            "-pp",
-            PREPROCESSED_TOPOLOGY_FILE,
-        ]
-        self._run_gromacs(cmd, cwd=input_dir, log_prefix="topology_pp")
-        topo_pp = input_dir / PREPROCESSED_TOPOLOGY_FILE
+        preproc_mdp = f"{PREPROCESSED_PREFIX}.mdp"
+        gromacs_utils.preprocess_topology(
+            input_dir=input_dir,
+            params=self.input_overrides,
+            structure_name=self.structure_file,
+            output_prefix=PREPROCESSED_PREFIX,
+            output_mdp_name=preproc_mdp,
+        )
+        topo_pp = input_dir / f"{PREPROCESSED_PREFIX}.top"
 
         if not topo_pp.exists():
             raise FileNotFoundError(f"Preprocessed topology file not found after grompp: {topo_pp}")

--- a/mythos/simulators/gromacs/gromacs.py
+++ b/mythos/simulators/gromacs/gromacs.py
@@ -135,11 +135,14 @@ class GromacsSimulator(InputDirSimulator):
         gromacs_utils.preprocess_topology(
             input_dir=input_dir,
             params=overrides,
-            structure_name=structure_file,
-            topology_name=f"{PREPROCESSED_PREFIX}.top",
             output_prefix=OUTPUT_PREFIX,
             output_mdp_name=step_mdp,
             log_prefix=f"{step}_grompp",
+            gromacs_binary=self.binary_path,
+            mdp_name=self.mdp_file,
+            structure_name=structure_file,
+            topology_name=f"{PREPROCESSED_PREFIX}.top",
+            index_name=self.index_file,
         )
 
         # run the simulation
@@ -186,10 +189,14 @@ class GromacsSimulator(InputDirSimulator):
         gromacs_utils.preprocess_topology(
             input_dir=input_dir,
             params=self.input_overrides,
-            structure_name=self.structure_file,
             output_prefix=PREPROCESSED_PREFIX,
             output_mdp_name=preproc_mdp,
             log_prefix="topology_pp",
+            gromacs_binary=self.binary_path,
+            mdp_name=self.mdp_file,
+            structure_name=self.structure_file,
+            topology_name=self.topology_file,
+            index_name=self.index_file,
         )
         topo_pp = input_dir / f"{PREPROCESSED_PREFIX}.top"
 

--- a/mythos/simulators/gromacs/gromacs.py
+++ b/mythos/simulators/gromacs/gromacs.py
@@ -139,6 +139,7 @@ class GromacsSimulator(InputDirSimulator):
             topology_name=f"{PREPROCESSED_PREFIX}.top",
             output_prefix=OUTPUT_PREFIX,
             output_mdp_name=step_mdp,
+            log_prefix=f"{step}_grompp",
         )
 
         # run the simulation

--- a/mythos/simulators/gromacs/gromacs.py
+++ b/mythos/simulators/gromacs/gromacs.py
@@ -189,6 +189,7 @@ class GromacsSimulator(InputDirSimulator):
             structure_name=self.structure_file,
             output_prefix=PREPROCESSED_PREFIX,
             output_mdp_name=preproc_mdp,
+            log_prefix="topology_pp",
         )
         topo_pp = input_dir / f"{PREPROCESSED_PREFIX}.top"
 

--- a/mythos/simulators/gromacs/tests/test_gromacs.py
+++ b/mythos/simulators/gromacs/tests/test_gromacs.py
@@ -603,3 +603,43 @@ class TestUpdateTopologyParams:
             pytest.raises(FileNotFoundError, match="Preprocessed topology file not found"),
         ):
             sim.run(seed=42)
+
+
+class TestPreprocessTopology:
+    """Tests for the preprocess_topology utility function."""
+
+    def test_copy_to_copies_input_and_preprocesses_in_copy(
+        self,
+        gromacs_input_dir: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Test that copy_to copies input files to the target directory and runs grompp there."""
+        from mythos.simulators.gromacs.utils import preprocess_topology
+
+        copy_dest = tmp_path / "archive"
+
+        commands_run = []
+
+        def mock_check_call(cmd, cwd=None, **kwargs):
+            commands_run.append({"cmd": cmd, "cwd": cwd})
+            return 0
+
+        with (
+            patch("mythos.simulators.gromacs.utils.shutil.which", return_value="gmx"),
+            patch("subprocess.check_call", side_effect=mock_check_call),
+        ):
+            preprocess_topology(
+                input_dir=gromacs_input_dir,
+                copy_to=copy_dest,
+            )
+
+        # The copy destination should exist with the original input files
+        assert copy_dest.exists()
+        assert (copy_dest / "md.mdp").exists()
+        assert (copy_dest / "topol.top").exists()
+        assert (copy_dest / "membrane.gro").exists()
+        assert (copy_dest / "index.ndx").exists()
+
+        # grompp should have been run in the copy, not the original
+        assert len(commands_run) == 1
+        assert Path(commands_run[0]["cwd"]) == copy_dest

--- a/mythos/simulators/gromacs/tests/test_gromacs.py
+++ b/mythos/simulators/gromacs/tests/test_gromacs.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
-from mythos.simulators.gromacs.gromacs import KB, PREPROCESSED_TOPOLOGY_FILE, GromacsSimulator
+from mythos.simulators.gromacs.gromacs import KB, PREPROCESSED_PREFIX, GromacsSimulator
 from mythos.simulators.io import SimulatorTrajectory
 
 # Test data directory
@@ -78,6 +78,12 @@ class TestGromacsSimulatorInstantiation:
 
 class TestGromacsSimulatorRun:
     """Tests for GromacsSimulator.run() method."""
+
+    @pytest.fixture(autouse=True)
+    def mock_shutil_which(self):
+        """Mock shutil.which in utils so the pre-flight binary check passes."""
+        with patch("mythos.simulators.gromacs.utils.shutil.which", return_value="gmx"):
+            yield
 
     @pytest.fixture
     def mock_subprocess_and_copy_outputs(self, gromacs_input_dir: Path):
@@ -536,6 +542,12 @@ class TestGromacsSimulatorTrajectory:
 class TestUpdateTopologyParams:
     """Tests for _update_topology_params method."""
 
+    @pytest.fixture(autouse=True)
+    def mock_shutil_which(self):
+        """Mock shutil.which in utils so the pre-flight binary check passes."""
+        with patch("mythos.simulators.gromacs.utils.shutil.which", return_value="gmx"):
+            yield
+
     def test_update_topology_params_creates_preprocessed_file(
         self,
         gromacs_input_dir: Path,
@@ -554,10 +566,10 @@ class TestUpdateTopologyParams:
             assert not cwd.samefile(gromacs_input_dir)  # Sanity check, we expect tmpdir
             if "grompp" in cmd and "-pp" in cmd:
                 # mock -pp making the expected preprocessed file
-                (cwd / PREPROCESSED_TOPOLOGY_FILE).write_text("; Preprocessed topology\n")
+                (cwd / f"{PREPROCESSED_PREFIX}.top").write_text("; Preprocessed topology\n")
             elif "grompp" in cmd:
                 # Test assertion ensuring we called and created in the correct dir and
-                assert (cwd / PREPROCESSED_TOPOLOGY_FILE).exists(), "Preprocessed topology should exist"
+                assert (cwd / f"{PREPROCESSED_PREFIX}.top").exists(), "Preprocessed topology should exist"
             if "mdrun" in cmd:
                 # to satisfy the completion of a run
                 shutil.copy(TEST_DATA_DIR / "output.tpr", cwd / "output.tpr")

--- a/mythos/simulators/gromacs/tests/test_gromacs.py
+++ b/mythos/simulators/gromacs/tests/test_gromacs.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 from mythos.simulators.gromacs.gromacs import KB, PREPROCESSED_PREFIX, GromacsSimulator
+from mythos.simulators.gromacs.utils import preprocess_topology
 from mythos.simulators.io import SimulatorTrajectory
 
 # Test data directory
@@ -614,8 +615,6 @@ class TestPreprocessTopology:
         tmp_path: Path,
     ) -> None:
         """Test that copy_to copies input files to the target directory and runs grompp there."""
-        from mythos.simulators.gromacs.utils import preprocess_topology
-
         copy_dest = tmp_path / "archive"
 
         commands_run = []

--- a/mythos/simulators/gromacs/utils.py
+++ b/mythos/simulators/gromacs/utils.py
@@ -92,8 +92,8 @@ def preprocess_topology(
     input_dir = Path(input_dir)
 
     # pre-emptively check for the GROMACS binary before copying files
-    gromacs_binary = gromacs_binary or shutil.which("gmx")
-    if gromacs_binary is None or not Path(gromacs_binary).exists():
+    gromacs_binary = shutil.which(gromacs_binary or "gmx")
+    if not gromacs_binary:
         raise FileNotFoundError(f"GROMACS binary not found or does not exist at: {gromacs_binary}")
 
     if copy_to is not None:

--- a/mythos/simulators/gromacs/utils.py
+++ b/mythos/simulators/gromacs/utils.py
@@ -92,9 +92,10 @@ def preprocess_topology(
     input_dir = Path(input_dir)
 
     # pre-emptively check for the GROMACS binary before copying files
-    gromacs_binary = shutil.which(gromacs_binary or "gmx")
+    binary_name = gromacs_binary or "gmx"
+    gromacs_binary = shutil.which(binary_name)
     if not gromacs_binary:
-        raise FileNotFoundError(f"GROMACS binary not found or does not exist at: {gromacs_binary}")
+        raise FileNotFoundError(f"GROMACS binary not found or does not exist at: {binary_name}")
 
     if copy_to is not None:
         # Copy the input directory to the specified location to avoid modifying original files

--- a/mythos/simulators/gromacs/utils.py
+++ b/mythos/simulators/gromacs/utils.py
@@ -61,7 +61,7 @@ def preprocess_topology(
     copy_to: Path | None = None,
     output_prefix: str = "preprocessed",
     output_mdp_name: str = "preprocessed.mdp",
-    gromacs_binary: str | None = None,
+    gromacs_binary: str | Path | None = None,
     mdp_name: str = "md.mdp",
     topology_name: str = "topol.top",
     structure_name: str = "membrane.gro",
@@ -79,6 +79,7 @@ def preprocess_topology(
         input_dir: Directory containing the GROMACS input files.
         params: Optional dictionary of parameters to update in the .mdp file.
         copy_to: Optional directory to copy input files to before preprocessing.
+           If the directory exists, an exception is raised.
         output_prefix: Prefix for the preprocessed topology (.top extension)
             and tpr files (.tpr extension).
         output_mdp_name: Name of the output .mdp file after replacements.

--- a/mythos/simulators/gromacs/utils.py
+++ b/mythos/simulators/gromacs/utils.py
@@ -1,6 +1,7 @@
 """Utilities for the GROMACS simulator."""
 
 import logging
+import shutil
 from pathlib import Path
 
 import jax_md
@@ -8,6 +9,8 @@ import MDAnalysis
 import numpy as np
 
 import mythos.simulators.io as jd_sio
+from mythos.input.gromacs_input import update_mdp_params
+from mythos.utils.helpers import run_command
 
 # MDAnalysis reads into Angstroms, but Gromacs parameters in nm
 ANGSTROMS_TO_NM = 0.1
@@ -50,3 +53,70 @@ def read_trajectory_mdanalysis(topology_file: Path, trajectory_file: Path) -> jd
         orientation=jax_md.rigid_body.Quaternion(vec=quaternions),
         box_size=box_sizes * ANGSTROMS_TO_NM,
     )
+
+
+def preprocess_topology(
+    input_dir: str | Path,
+    params: dict | None = None,
+    copy_to: Path | None = None,
+    output_prefix: str = "preprocessed",
+    output_mdp_name: str = "preprocessed.mdp",
+    gromacs_binary: str | None = None,
+    mdp_name: str = "md.mdp",
+    topology_name: str = "topol.top",
+    structure_name: str = "membrane.gro",
+    index_name: str = "index.ndx",
+    log_prefix: str = "topology_preprocess",
+) -> None:
+    """Preprocess a GROMACS topology.
+
+    This function runs `gmx grompp` to preprocess the GROMACS topology, applying
+    any parameter updates to the .mdp file as needed. The preprocessed topology
+    will be saved with the specified output prefix. Optionally copies input
+    files to a new location to avoid modifying originals.
+
+    Args:
+        input_dir: Directory containing the GROMACS input files.
+        params: Optional dictionary of parameters to update in the .mdp file.
+        copy_to: Optional directory to copy input files to before preprocessing.
+        output_prefix: Prefix for the preprocessed topology (.top extension)
+            and tpr files (.tpr extension).
+        output_mdp_name: Name of the output .mdp file after replacements.
+        gromacs_binary: Optional path to the GROMACS binary (defaults to 'gmx' in PATH).
+        mdp_name: Name of the .mdp file in the input directory.
+        topology_name: Name of the topology file in the input directory.
+        structure_name: Name of the structure file in the input directory.
+        index_name: Name of the index file in the input directory.
+        log_prefix: Prefix for log messages.
+    """
+    input_dir = Path(input_dir)
+
+    # pre-emptively check for the GROMACS binary before copying files
+    gromacs_binary = gromacs_binary or shutil.which("gmx")
+    if gromacs_binary is None or not Path(gromacs_binary).exists():
+        raise FileNotFoundError(f"GROMACS binary not found or does not exist at: {gromacs_binary}")
+
+    if copy_to is not None:
+        # Copy the input directory to the specified location to avoid modifying original files
+        copy_dir = Path(copy_to)
+        shutil.copytree(input_dir, copy_dir)
+        input_dir = copy_dir
+
+    update_mdp_params(input_dir / mdp_name, params or {}, out_file=input_dir / output_mdp_name)
+    cmd = [
+        gromacs_binary,
+        "grompp",
+        "-p",
+        topology_name,
+        "-f",
+        output_mdp_name,
+        "-c",
+        structure_name,
+        "-n",
+        index_name,
+        "-pp",
+        f"{output_prefix}.top",
+        "-o",
+        f"{output_prefix}.tpr",
+    ]
+    run_command(cmd, cwd=input_dir, log_prefix=log_prefix)


### PR DESCRIPTION
Make a util function and script for the common operation of generating preprocessed topology files from a gromacs system directory. These are needed (`preprocessed.top`) to initialize the energy function with parameters, and the get a universe (`preprocessed.tpr`) - all prior to running a simulation.

These are also the same operations used in the simulator, so reduce its code by using the new utility for the preprocessing.

**Note**: Sneaking in a fix for the wasserstein observable, its tolerance seemed to be too tight for practical use in some cases, even using x64 