### PR TITLE
adding github action for pypi publishing on release

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,0 +1,70 @@
+name: DIST
+on:
+  release:
+    types: [ released, prereleased ]
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+    - name: Install dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        pip3 install -r requirements/dev.txt
+      shell: bash
+    - name: Build a binary wheel and a source tarball
+      run: tox -e build-dist
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-testpypi:
+    name: Publish to TestPyPI
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/mythos-bio
+    permissions:
+      id-token: write
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4.1.7
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+    - build
+    - publish-to-testpypi
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mythos-bio
+    permissions:
+      id-token: write
+    steps:
+    - name: Download dists from
+      uses: actions/download-artifact@v4.1.7
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Publish to pypi test and, conditional on that succeeding, publish on main pypi. Only on releases

**Note**: This was copied from dplutils repo, only the repo location changed - publishers prepared in both pypi and testpypi under my account for now